### PR TITLE
Update to use stream transcription all the way to the end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@albertsyh/use-whisper",
-  "version": "0.2.14",
+  "version": "0.2.2",
   "description": "React Hook for OpenAI Whisper API with speech recorder and silence removal built-in.",
   "keywords": [
     "react",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,10 @@ export type UseWhisperConfig = {
   timeSlice?: number
   whisperConfig?: WhisperApiConfig
   onDataAvailable?: (blob: Blob) => void
-  onTranscribeWhenSilent?: (blob: Blob) => Promise<UseWhisperTranscript>
+  onTranscribeWhenSilent?: (
+    blob?: Blob,
+    complete?: boolean
+  ) => Promise<UseWhisperTranscript>
   onTranscribe?: (blob: Blob) => Promise<UseWhisperTranscript>
   onStreamTranscribe?: (blob: Blob) => Promise<UseWhisperTranscript>
   onRecord?: (blob: Blob, arrayBuffer: ArrayBuffer | null) => void


### PR DESCRIPTION
The big problem we're trying to fix is that we need that final onTranscribe callback to know when the last job has been posted. We also have the unfixable problem that onDataAvailable isn't flushed when you stop recording so you're fated to lose that last unfinished chunk.

Here, we flush all the unsilent chunks remaining to onTranscribeWhenSilent when the recording is done, with a complete parameter to let it know that no more are coming.

hrishi/new-features in whisper-to-me make use of this!